### PR TITLE
Improve apps search

### DIFF
--- a/src/cheatsheet.py
+++ b/src/cheatsheet.py
@@ -119,6 +119,7 @@ def addApps(items):
     for i in range(0,len(items)):
         item = items[i]
         wf.add_item(item,
+                    uid=item,
                     autocomplete=' '+item,
                     arg=item,
                     valid=True)


### PR DESCRIPTION
This small improvement makes the app search better. For example, if you type <kbd>T</kbd> and always select _Things_ after few times _Things_ will be rendered as the first item in the search results. This is a default Alfred feature, we just need to set a UID for every app item.

![Before](https://user-images.githubusercontent.com/923973/42886890-6318eb62-8aad-11e8-8481-f69e61c3f4a5.png)
![After](https://user-images.githubusercontent.com/923973/42886891-63380df8-8aad-11e8-959f-a093ea439dbe.png)
