### PR TITLE
Allow to show/hide specific apps in search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,38 @@ To add more apps
 - to share with everyone, create a PR with the app shortcuts you want to add [/src/shortcuts.py]. Please also include the app icon (`src/apps/icons/%APP NAME%.png`).
 - create an issue requesting the tool you want us to add
 
+To show or hide apps in search results
+----------------
+Open `settings.json` in your data directory.
+To show only some specific apps in the search results list them in `show_only_apps` parameter:
+```json
+{
+  "__workflow_last_version": "1.3.0",
+  "show_only_apps": [
+    "Alfred",
+    "Mac OSX",
+    "Terminal"
+  ]
+}
+```
+All other apps would be hidden then.
+
+
+To hide some apps in the search results list them in `hide_apps` parameter:
+```json
+{
+  "__workflow_last_version": "1.3.0",
+  "hide_apps": [
+    "Microsoft Word",
+    "Video Speed Controller chrome extension"
+  ]
+}
+```
+
+
+
+
+
 Steps to release workflow:
 ----------------
 1. pull latest changes from master

--- a/src/cheatsheet.py
+++ b/src/cheatsheet.py
@@ -40,7 +40,7 @@ def check_update():
 
 def add_edit_custom_info():
     wf.add_item('Customize your cheatsheet',
-            'Edit custom.json file to personalize cheatsheet',
+            'Edit custom.json to personalize cheatsheet. Edit settings.json to hide apps in search results.',
             arg='opendata',
             valid=True,
             icon=ICON_INFO)
@@ -108,9 +108,16 @@ def filter(query, items):
 
 # returns a list of the apps available as shortcuts
 def getApps():
-    apps = shortcuts.keys()
+    built_in_apps = shortcuts.keys()
     custom_apps = custom.keys()
-    return list(set(apps)|set(custom_apps))
+    apps = list(set(built_in_apps) | set(custom_apps))
+
+    if 'show_only_apps' in wf.settings:
+        apps = [app for app in apps if app in wf.settings['show_only_apps']]
+    elif 'hide_apps' in wf.settings:
+        apps = [app for app in apps if app not in wf.settings['hide_apps']]
+
+    return apps
 
 def getShorcuts(app):
     opts = []


### PR DESCRIPTION
This PR implements #9. I haven't implemented any related GUI, so, for now, apps should be listed in `settings.json` (I documented how to do that). I also suggest that we keep #9 open for anyone who wants to implement the GUI.